### PR TITLE
Real server hotfix: Facebook saving images duplication fixed, User update API fixed (dev -> Dev)

### DIFF
--- a/app/members/backends.py
+++ b/app/members/backends.py
@@ -70,8 +70,7 @@ class APIFacebookBackend:
             # (최초 로그인 user의 경우에만!)
             # Facebook에서 받아온 사진으로 img_profile 저장
             if user.is_facebook_user is False:
-                user.is_facebook_user = True
-                # temp_file = download(img_profile_url)
+                temp_file = download(img_profile_url)
                 # file_name = '{facebook_id}.{ext}'.format(
                 #     facebook_id=facebook_id,
                     # facebook_id='img_profile',
@@ -83,11 +82,18 @@ class APIFacebookBackend:
                 binary_data = response.content
 
                 img = UserProfileImages.objects.create(user=user)
+
+                # print(ContentFile(binary_data))
+                # print(type(ContentFile(binary_data)))
+
+                # print(File(temp_file))
+                # print(type(File(temp_file)))
+
+                # img.img_profile.save('img_profile.png', File(temp_file))
                 img.img_profile.save('img_profile.png', ContentFile(binary_data))
-                # user.save()
-                # 사진 리사이징 및 저장
-                # (utils/image/resize.py)
-                # img_resize(user, file_name)
+
+                user.is_facebook_user = True
+                user.save()
 
             return user
 

--- a/app/members/serializers/auth.py
+++ b/app/members/serializers/auth.py
@@ -152,7 +152,6 @@ class UserUpdateSerializer(serializers.ModelSerializer):
             result = imf.to_internal_value(images)
             # print(result)
 
-
         return attrs
 
     def update(self, user, validated_data):
@@ -181,7 +180,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
         user.save()
 
         # 유저가 사진을 입력안한 경우( 기존 이미지 또는 default 이미지로 다시 넣어준다.
-        if img_profile == '':
+        if img_profile == []:
             # '' 값은 위의 img_profile = validated_data.get('img_profile', '')
             # 에서 img_profile 값이 입력되지 않았을 경우인데,
             # 이게 Postman 문제인지는 모르겠지만 null값을 보낼때와 빈 값('')을 보낼 때와
@@ -208,19 +207,27 @@ class UserUpdateSerializer(serializers.ModelSerializer):
             # img = UserProfileImages.objects.create(user=user)
             # img.img_profile.save('img_profile.png', ContentFile(file))
 
+            # 3) 4/10 오전 미팅결과 iOS/FDS에서 Default image 세팅하기로 결론
+
         else:
             # 이미지가 입력된 경우 별도의 단계 없이 바로 해당 이미지를 저장한다.
             # if user.img_profile:
             #     if os.path.isfile(user.img_profile.path):
             #         os.remove(user.img_profile.path)
-            pass
-            # user.images.all().delete()
+
+            user.images.all().delete()
             # user.images.create(img_profile=img_profile)
 
-            # f = img_profile.read()
-            # print(f)
+            # 4/10 content.seek(0) 에러 발생으로 이미지 저장 방법 변경
+            #       만약 아래 방법으로 해결된다면 Cache를 이용하여
+            #       이미지를 저장하는 라이브러리 특성상, 객체를 생성과 동시에
+            #       이미지를 저장하려고 할 때 오류가 난 것으로 추측.
+            img = UserProfileImages.objects.create(user=user)
 
-            # img = UserProfileImages.objects.get(user=user)
+            # 1) 먼저 생각난 방법
             # img.img_profile.save('img_profile.png', img_profile)
+
+            # 2) 일단 안전빵
+            img.img_profile.save('img_profile.png', ContentFile(img_profile.read()))
 
         return user


### PR DESCRIPTION
Real server hotfix: Facebook saving images duplication fixed, User update API fixed (dev -> Dev)

1. 페이스북 로그인 시 이미지 중복 저장 해결
2. 업데이트 부분 content.seek(0) 오류 해결(?)
* User Delete API 에러는 S3 접속 권한 문제로 추측